### PR TITLE
Fix unit test errors and avoid network

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Then open [http://127.0.0.1:8000/docs](http://127.0.0.1:8000/docs) for interacti
 
 ## 🧪 Running Unit Tests
 
+Before running the tests make sure all dependencies are installed:
+
+```bash
+pip install -r requirements.txt
+```
+
 To run all unit tests locally:
 
 ```bash

--- a/astro_core.py
+++ b/astro_core.py
@@ -24,16 +24,17 @@ OFFLINE_COORDS = {
 
 
 def calculate_chart(date: str, time: str, place: str, tz_offset: int):
-    try:
-        geo = Nominatim(user_agent="astro_api").geocode(place)
-    except GeocoderServiceError:
-        geo = None
-    if not geo:
-        if place in OFFLINE_COORDS:
-            lat, lon = OFFLINE_COORDS[place]
-        else:
-            return None, {"error": "Invalid place name"}
+    if place in OFFLINE_COORDS:
+        # Avoid unnecessary network requests during testing by using
+        # predefined coordinates for common cities.
+        lat, lon = OFFLINE_COORDS[place]
     else:
+        try:
+            geo = Nominatim(user_agent="astro_api").geocode(place)
+        except GeocoderServiceError:
+            geo = None
+        if not geo:
+            return None, {"error": "Invalid place name"}
         lat, lon = geo.latitude, geo.longitude
     local = datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M")
     utc_time = local - timedelta(hours=tz_offset)


### PR DESCRIPTION
## Summary
- clarify test setup instructions in README
- avoid network calls in `calculate_chart` when possible

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c783e83b8832aa663e8b260f1ba20